### PR TITLE
Uninitialized variable (res) in scewl_recv

### DIFF
--- a/cpu/scewl_bus_driver/scewl_bus_driver.c
+++ b/cpu/scewl_bus_driver/scewl_bus_driver.c
@@ -128,7 +128,7 @@ int full_read(int sock, void *vbuf, int n) {
 int scewl_recv(char *buf, scewl_id_t *src_id, scewl_id_t *tgt_id,
                size_t n, int blocking) {
   scewl_hdr_t hdr;
-  int res, max, bread, flags, dummy;
+  int res=SCEWL_OK, max, bread, flags, dummy;
 
   // set blocking
   flags = fcntl(sock, F_GETFL, 0);


### PR DESCRIPTION
In the scewl_recv function, if the uninitialized variable "res" happens to pick up the value "2" from previously used RAM, the error catch for SCEWL_NO_MSG on line 184 generates a false NO MSG and returns an error code.  The calling program receives the error which prevents the data transfer when the data is actually valid.  The problem persists until a different RAM location is used when calling scewl_recv.  Initializing the res variable to SCEWL_OK enum fixes the issue.